### PR TITLE
fix: Dont disconnect wallet on account switch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@headlessui/react": "2.1.1",
     "@heroicons/react": "2.1.3",
     "@near-wallet-selector/ethereum-wallets": "8.9.14",
+    "@aurora-is-near/ethereum-wallets": "1.0.0-alpha.23",
     "@near-wallet-selector/account-export": "8.9.14",
     "@near-wallet-selector/core": "8.9.14",
     "@near-wallet-selector/here-wallet": "8.9.14",

--- a/src/contexts/WalletSelectorContext.tsx
+++ b/src/contexts/WalletSelectorContext.tsx
@@ -9,7 +9,7 @@ import type { WalletSelectorModal } from "@near-wallet-selector/modal-ui";
 import { setupModal } from "@near-wallet-selector/modal-ui";
 import { setupMyNearWallet } from "@near-wallet-selector/my-near-wallet";
 import { setupWalletConnect } from "@near-wallet-selector/wallet-connect";
-import { setupEthereumWallets } from "@near-wallet-selector/ethereum-wallets";
+import { setupEthereumWallets } from "@aurora-is-near/ethereum-wallets";
 import { setupMeteorWallet } from "@near-wallet-selector/meteor-wallet";
 import { setupHereWallet } from "@near-wallet-selector/here-wallet";
 import type { ReactNode } from "react";

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,18 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@aurora-is-near/ethereum-wallets@1.0.0-alpha.23":
+  version "1.0.0-alpha.23"
+  resolved "https://registry.yarnpkg.com/@aurora-is-near/ethereum-wallets/-/ethereum-wallets-1.0.0-alpha.23.tgz#305b54f3f1dccdb0511686a715cf85d6e56a1262"
+  integrity sha512-12t0ApoDhw6zGu6xZCWqM1LNRvNFvfADHlrK1gEfzqWTc+NbLohCVEeROouN8n4UyhRIsqMtiP0u7B2oPiAAvQ==
+  dependencies:
+    "@near-wallet-selector/core" "8.9.14"
+    "@near-wallet-selector/wallet-utils" "8.9.14"
+    "@wagmi/core" "2.11.6"
+    bs58 "5.0.0"
+    near-api-js "4.0.3"
+    viem "2.16.2"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.24.7.tgz#882fd9e09e8ee324e496bd040401c6f046ef4465"


### PR DESCRIPTION
Fix a bug when using skipSignInAccessKey which causes the wallet to be disconnected when the connected account is changed: https://github.com/near/wallet-selector/pull/1221