### PR TITLE
Improve the test ids for elements which are btn+href->links in the end

### DIFF
--- a/src/components/Staking/components/StakedBalance.tsx
+++ b/src/components/Staking/components/StakedBalance.tsx
@@ -44,7 +44,9 @@ export default function StakedBalance({
                   className="!text-sand-12"
                   disabled={!canUnstake}
                   href={unstakeHref}
-                  data-testid="unstake-stake-button"
+                  data-testid={
+                    canUnstake ? "unstake-btn" : "unstake-btn-disabled"
+                  }
                 >
                   Unstake
                 </Button>
@@ -78,7 +80,9 @@ export default function StakedBalance({
                 disabled={!canWithdraw}
                 href={withdrawHref}
                 className="!h-10 !w-fit !px-5 !text-sm !font-semibold !tracking-[0.28px]"
-                data-testid="withdraw-stake-button"
+                data-testid={
+                  canWithdraw ? "withdraw-btn" : "withdraw-btn-disabled"
+                }
               >
                 Withdraw
               </Button>


### PR DESCRIPTION
This PR is improvement of previous PR due to peculiar behavior - Buttons with links in React are converted to links (which by HTML standard cannot be disabled). These changes make alternating test IDs depending on the state - either can withdraw/stake or not.

Links for info:
- [SO link for HTML "a" disabled state](https://stackoverflow.com/a/10276157)
![Screenshot 2025-01-17 at 10 13 45](https://github.com/user-attachments/assets/07f5be95-f42c-4fb5-bdfb-446dce16c51f)